### PR TITLE
2. Save Timetable Name (Points: 4)

### DIFF
--- a/client/src/pages/BuildTimetable/BuildTimetable.tsx
+++ b/client/src/pages/BuildTimetable/BuildTimetable.tsx
@@ -1,19 +1,20 @@
-import { Central as Layout } from "@/layouts";
-import { Section } from "./Section";
-import { SearchSection } from "./SearchSection";
-import { ResultsSection } from "./ResultsSection";
-import { TimetableSection } from "./TimetableSection";
-import { useState } from "react";
+import { useAccountContext } from "@/context";
 import { ServiceAPI } from "@/infrastructure";
 import { ScheduledEvent } from "@/infrastructure/ServiceAPI";
-import { WorksheetSection } from "./WorksheetSection";
-import { useAccountContext } from "@/context";
-import { useNavigate } from "react-router-dom";
+import { Central as Layout } from "@/layouts";
 import { scheduledEventToCalendarBlock } from "@/utils";
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
 import "./BuildTimetable.style.scss";
+import { ResultsSection } from "./ResultsSection";
+import { SearchSection } from "./SearchSection";
+import { Section } from "./Section";
+import { TimetableSection } from "./TimetableSection";
+import { WorksheetSection } from "./WorksheetSection";
 
 function BuildTimetable() {
   const { jwt } = useAccountContext();
+  const [timetableName, setTimetableName] = useState(new Date().toISOString());
   const [scheduledEvents, setScheduledEvents] = useState<ScheduledEvent[]>([]);
   const [selectedEvents, setSelectedEvents] = useState<ScheduledEvent[]>([]);
   const navigate = useNavigate();
@@ -25,7 +26,7 @@ function BuildTimetable() {
 
   const createTimetable = async () => {
     const result = await ServiceAPI.createTimetable(
-      new Date().toISOString(),
+      timetableName,
       selectedEvents.map((event) => event.id.toString()),
       jwt,
     );
@@ -60,6 +61,7 @@ function BuildTimetable() {
             <WorksheetSection
               selectedEvents={selectedEvents}
               removeEvent={removeEvent}
+              setTimetableName={setTimetableName}
               createTimetable={createTimetable}
             />
           </Section>

--- a/client/src/pages/BuildTimetable/WorksheetSection/WorksheetSection.tsx
+++ b/client/src/pages/BuildTimetable/WorksheetSection/WorksheetSection.tsx
@@ -3,12 +3,14 @@ import "./WorksheetSection.style.scss";
 interface WorksheetSectionProps {
   selectedEvents: ScheduledEvent[];
   removeEvent: (event: ScheduledEvent) => void;
+  setTimetableName: (value: string) => void;
   createTimetable: () => void;
 }
 
 function WorksheetSection({
   selectedEvents,
   removeEvent,
+  setTimetableName,
   createTimetable,
 }: WorksheetSectionProps) {
   return (
@@ -63,6 +65,8 @@ function WorksheetSection({
           ))}
         </tbody>
       </table>
+      <label>Name:</label>
+      <input type="text" onChange={e => setTimetableName(e.target.value)} />
       <button onClick={createTimetable}>Create Timetable</button>
     </div>
   );

--- a/client/src/pages/ViewTimetable/ViewTimetable.tsx
+++ b/client/src/pages/ViewTimetable/ViewTimetable.tsx
@@ -1,11 +1,11 @@
-import { Central as Layout } from "@/layouts";
 import { Timetable as TimetableView } from "@/components";
-import { useEffect, useState } from "react";
-import { ServiceAPI } from "@/infrastructure";
-import { useParams } from "react-router-dom";
 import { useAccountContext } from "@/context";
+import { ServiceAPI } from "@/infrastructure";
 import { Timetable } from "@/infrastructure/ServiceAPI";
+import { Central as Layout } from "@/layouts";
 import { scheduledEventToCalendarBlock } from "@/utils";
+import { useEffect, useState } from "react";
+import { useParams } from "react-router-dom";
 import "./ViewTimetable.style.scss";
 
 function ViewTimetable() {
@@ -35,7 +35,7 @@ function ViewTimetable() {
   }
 
   return (
-    <Layout title={"Student Timetable"}>
+    <Layout title={timetable.name}>
       <TimetableView
         events={timetable.items.map((item: any) =>
           scheduledEventToCalendarBlock(item),


### PR DESCRIPTION
Add functionality to allow users to **save a custom name** for their timetables. This will help users identify their timetables more easily when managing multiple schedules.

In the client, create an input field on the [BuildTimetable](https://github.com/CarletonComputerScienceSociety/hack-the-tunnels-starter-2024/blob/8f7769a7223bb3e2ac4e95ced1f64373444fd838/client/src/pages/BuildTimetable/BuildTimetable.tsx) page where users can enter a name for their timetable.

Update the `createTimetable` method to use the input from your newly created [input element](https://www.w3schools.com/tags/tag_input.asp).

Utilize React’s [useState](https://legacy.reactjs.org/docs/hooks-state.html) hook to store the name.

Acceptance Criteria:
- A text input field is added on the BuildTimetable page where users can enter a name for their timetable.
- The name is saved in the backend when the timetable is created or updated.
- The saved name is displayed when viewing or managing timetables.